### PR TITLE
Select the parent of the script containing `import.meta.document`

### DIFF
--- a/src/html-module-transform.ts
+++ b/src/html-module-transform.ts
@@ -51,7 +51,7 @@ export const htmlModuleToJsModuleMap =
 
       if (property.type === 'Identifier') {
         memberExpression.replaceWith(ast`($documentModule.querySelector(${
-            importMetaScriptElementSelector}))`);
+            importMetaScriptElementSelector}).parentElement)`);
       }
     }
 


### PR DESCRIPTION
See https://github.com/PolymerLabs/html-modules-toolkit/issues/14.
Aligns the transform for import.meta.document with the explainer/proposal at https://github.com/w3c/webcomponents/blob/gh-pages/proposals/html-modules-explainer.md